### PR TITLE
Update ethernet_packet.js

### DIFF
--- a/decode/ethernet_packet.js
+++ b/decode/ethernet_packet.js
@@ -49,7 +49,7 @@ EthernetPacket.prototype.decode = function (raw_packet, offset) {
             this.payload = "need to implement LLDP";
             break;
         default:
-            console.log("node_pcap: EthernetFrame() - Don't know how to decode ethertype " + this.ethertype);
+            this.payload = "node_pcap: EthernetFrame() - Don't know how to decode ethertype " + this.ethertype;
         }
     }
 


### PR DESCRIPTION
To prevent the console or if using log files from filling up with: 
"node_pcap: EthernetFrame() - Don't know how to decode ethertype ######"
I propose redirecting the output to the payload just like LLDP.
